### PR TITLE
Consistently normalize paths

### DIFF
--- a/R/rawrr.R
+++ b/R/rawrr.R
@@ -3,7 +3,7 @@
     system2("mono", "-V", stdout = TRUE)
 }
 
-  .checkReaderFunctions <- function(rawfile = sampleFilePath()){
+.checkReaderFunctions <- function(rawfile = sampleFilePath()){
   
   message("checkings rawrr::readFileHeader ...")
   start_time <- Sys.time()
@@ -53,10 +53,8 @@
 }
 
 .checkRawFile <- function(rawfile){
-  rawfile <- normalizePath(rawfile)
-  
   if (!file.exists(rawfile)){
-    msg <- sprintf("File '%s'  is not available.", rawfile)
+    msg <- sprintf("File '%s' does not exist.", rawfile)
     stop(msg)
   }
   
@@ -87,7 +85,6 @@
   function(rawfile, input, rawrrArgs="scans", tmpdir=tempdir(),
            removeTempfile=TRUE){
     
-
     mono <- if(Sys.info()['sysname'] %in% c("Darwin", "Linux")) TRUE else FALSE
     exe <- .rawrrAssembly()
     
@@ -220,6 +217,7 @@ is.rawrrSpectrumSet <- function(x){
 #' rawrr::sampleFilePath() |> readFileHeader()
 readFileHeader <- function(rawfile){
   .isAssemblyWorking()
+  rawfile <- normalizePath(rawfile)
   .checkRawFile(rawfile)
 
   e <- .rawrrSystem2Source(rawfile, input = NULL, rawrrArgs="headerR")
@@ -248,6 +246,7 @@ readFileHeader <- function(rawfile){
 readIndex <- function (rawfile) 
 {
   .isAssemblyWorking()
+  rawfile <- normalizePath(rawfile)
   .checkRawFile(rawfile)
   mono <- if (Sys.info()["sysname"] %in% c("Darwin", "Linux")) 
     TRUE
@@ -280,6 +279,7 @@ readIndex <- function (rawfile)
 #' @return a vecntor of integer values.
 filter <- function(rawfile, filter = "ms", precision = 10, tmpdir=tempdir()){
   .isAssemblyWorking()
+  rawfile <- normalizePath(rawfile)
   .checkRawFile(rawfile)
   mono <- if(Sys.info()['sysname'] %in% c("Darwin", "Linux")) TRUE else FALSE
   exe <- .rawrrAssembly()
@@ -578,6 +578,7 @@ sampleFilePath <- function(){
 readSpectrum <- function(rawfile, scan = NULL, tmpdir = tempdir(),
                          validate = FALSE, mode = ''){
   .isAssemblyWorking()
+  rawfile <- normalizePath(rawfile)
   .checkRawFile(rawfile)
   
   if (is.null(scan)){
@@ -772,6 +773,7 @@ readChromatogram <- function(rawfile,
                              tmpdir = tempdir()){
     
     .isAssemblyWorking()
+    rawfile <- normalizePath(rawfile)
     .checkRawFile(rawfile)
     
     stopifnot(type %in% c('xic', 'bpc', 'tic'))
@@ -1582,6 +1584,7 @@ auc.rawrrChromatogram <- function(x){
 #' rawrr::sampleFilePath() |> rawrr:::readTrailer("AGC:") |> head()
 readTrailer <- function(rawfile, label = NULL) {
   .isAssemblyWorking()
+  rawfile <- normalizePath(rawfile)
   .checkRawFile(rawfile)
   
   mono <- if(Sys.info()['sysname'] %in% c("Darwin", "Linux")) TRUE else FALSE

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -3,6 +3,12 @@
 
 \newcommand{\ghit}{\href{https://github.com/fgcz/rawrr/issues/#1}{##1}}
 
+\section{Changes in version 1.10.2 (Unreleased)}{
+  \itemize{
+    \item Consistently normalize paths \ghit{76}.
+  }
+}
+
 \section{Changes in version 1.10.1 (2023-11-02)}{
   \itemize{
 	  \item Fix index error \ghit{67}. 


### PR DESCRIPTION
Fixes #76

Input paths were normalized inconsistently before. This will be fixed by this PR and will also yield better error messages if a similar problem reoccurs.

As a result the simple Bash-style leading tilde expansion pattern is supported now (which was the problem in #76, not relative paths in general), more complex forms are not (e.g. `~user` or any other [more advanced](https://www.gnu.org/software/bash/manual/html_node/Tilde-Expansion.html) ones as these are very shell specific).

Note that these pattern features are widely unsupported or inconsistently supported by many tools and libraries, for instance the `md5sum` tool from GNU Coreutils doesn't understand the tilde either:

<img width="472" alt="grafik" src="https://github.com/user-attachments/assets/86b81608-cd26-403f-80da-f882fb3c07d2">

