### PR TITLE
Setup CD pipeline for rawrassembly

### DIFF
--- a/.github/workflows/cd_rawrrassembly.yml
+++ b/.github/workflows/cd_rawrrassembly.yml
@@ -1,0 +1,93 @@
+name: CD RawrrAssembly
+on:
+  workflow_dispatch:
+  release:
+    types: [created]
+env:
+  DOTNET_DOCKER: mcr.microsoft.com/dotnet/sdk:8.0
+jobs:
+  build:
+    name: Build Assembly
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Pull image
+        run: docker pull $DOTNET_DOCKER
+      - name: Build
+        run: cd inst/rawrrassembly && docker run --rm -v $PWD:/app -w /app $DOTNET_DOCKER /app/build.sh /app /app/out
+      - name: Publish results
+        uses: actions/upload-artifact@v4
+        with:
+          name: rawrr
+          path: inst/rawrrassembly/out
+          retention-days: 1
+  verify-linux:
+    name: Verify on Linux
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download results
+        uses: actions/download-artifact@v4
+        with:
+          name: rawrr
+      - name: List result
+        run: tree
+      - name: Make executable
+        run: chmod +x rawrr-linux-x64
+      - name: Execute on test file
+        run: ./rawrr-linux-x64 ./inst/extdata/sample.raw index
+  verify-windows:
+    name: Verify on Windows
+    runs-on: windows-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download results
+        uses: actions/download-artifact@v4
+        with:
+          name: rawrr
+      - name: List result
+        run: dir
+      - name: Execute on test file
+        run: .\rawrr-win-x64.exe .\inst\extdata\sample.raw index
+  verify-macos:
+    name: Verify on MacOS
+    runs-on: macos-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download results
+        uses: actions/download-artifact@v4
+        with:
+          name: rawrr
+      - name: List result
+        run: ls -l
+      - name: Make executable
+        run: chmod +x rawrr-osx-x64
+      - name: Execute on test file
+        run: ./rawrr-osx-x64 ./inst/extdata/sample.raw index
+  upload-release-artifacts:
+    name: Upload Release Artifacts
+    runs-on: ubuntu-latest
+    needs:
+      - verify-linux
+      - verify-windows
+      - verify-macos
+    if: github.event_name == 'release'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: rawrr
+          path: dist
+      - name: Upload Release Assets
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            dist/rawrr-linux-x64
+            dist/rawrr-win-x64.exe
+            dist/rawrr-osx-x64
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -16,6 +16,10 @@ on:
     branches: [ devel ]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   build:
     runs-on: ubuntu-20.04

--- a/inst/rawrrassembly/.gitignore
+++ b/inst/rawrrassembly/.gitignore
@@ -1,4 +1,4 @@
-ThermoFisher.CommonCore.Data.dll
-ThermoFisher.CommonCore.MassPrecisionEstimator.dll
-ThermoFisher.CommonCore.RawFileReader.dll
-rawrr.exe
+*.dll
+*.exe
+*.zip
+publish

--- a/inst/rawrrassembly/build.sh
+++ b/inst/rawrrassembly/build.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -euxo pipefail
+
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 <project_folder> <output_folder>"
+    exit 1
+fi
+project_folder="$1"
+output_folder="$2"
+work_folder="/tmp/build"
+
+# debug: 
+#apt-get update && apt-get upgrade -y && apt-get install -y zip tree
+
+# Checkout the deps
+mkdir /tmp/build-dir && cd /tmp/build-dir
+git clone --depth=1 https://github.com/thermofisherlsms/RawFileReader.git
+dotnet nuget add source "$PWD"/RawFileReader/Libs/NetCore/Net8/
+
+# Perform the release
+cp -r "$project_folder" "$work_folder"
+cd "$work_folder"
+runtimes="linux-x64 osx-x64 win-x64"
+for runtime in $runtimes; do
+    dotnet publish --runtime "$runtime" -c Release
+done
+
+# debug:
+#tree bin/Release/net8.0
+mkdir -p "$output_folder"
+
+# Export the result
+for runtime in $runtimes; do
+    source_path="bin/Release/net8.0/$runtime/publish"
+    suffix=""
+    if [[ "$runtime" == win-* ]]; then
+        suffix=".exe"
+    fi
+    cp "$source_path/rawrr$suffix" "$output_folder/rawrr-$runtime$suffix"
+done

--- a/inst/rawrrassembly/rawrr.csproj
+++ b/inst/rawrrassembly/rawrr.csproj
@@ -1,16 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework> <!-- Or net7.0, depending on your setup -->
     <AssemblyName>rawrr</AssemblyName>
-    <PublishSingleFile>true</PublishSingleFile> 
-    <SelfContained>true</SelfContained> 
+    <TargetFramework>net8.0</TargetFramework>
+    <SelfContained>true</SelfContained>
+    <PublishTrimmed>false</PublishTrimmed>
+    <PublishSingleFile>true</PublishSingleFile>
+    <PublishReadyToRun>true</PublishReadyToRun>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="ThermoFisher.CommonCore.BackgroundSubtraction" Version="8.0.6" />
-    <PackageReference Include="Thermofisher.CommonCore.MassPrecisionEstimator" Version="8.0.6" />
+    <PackageReference Include="ThermoFisher.CommonCore.Data" Version="8.0.6" />
+    <PackageReference Include="ThermoFisher.CommonCore.MassPrecisionEstimator" Version="8.0.6" />
     <PackageReference Include="ThermoFisher.CommonCore.RawFileReader" Version="8.0.6" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR serves to trigger the CD pipeline for development purposes.

This pipeline builds the rawrr assembly, tests it for mac, win, linux and then attaches the artifact to a release if it was triggered from a release (i.e. the workflow is to create GitHub release - can be in draft mode - and then wait for the pipeline to do its job).