### PR TITLE
Fix and optimize CI

### DIFF
--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -37,9 +37,10 @@ jobs:
         shell: bash {0}
       - name: Install dependencies
         run: |
-          install.packages(c("remotes", "covr", "rcmdcheck", "rmarkdown", "protViz", "testthat", "knitr", "BiocManager"))
-          BiocManager::install(c("BiocStyle", "ExperimentHub", "tartar"))
-          remotes::install_deps(dependencies = TRUE)
+          install.packages("pak", repos = sprintf("https://r-lib.github.io/p/pak/stable/%s/%s/%s", .Platform$pkgType, R.Version()$os, R.Version()$arch))
+          pak::pkg_install(c("covr", "rcmdcheck", "rmarkdown", "protViz", "testthat", "knitr"))
+          pak::pkg_install(c("bioc::BiocStyle", "bioc::ExperimentHub", "bioc::tartar"))
+          pak::local_install_deps(dependencies = TRUE)
         shell: Rscript {0}
       - name: Check
         run: rcmdcheck::rcmdcheck(build_args = "", args = "", error_on = "error", check_dir = "/tmp/rawrr.Rcheck")

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        r-version: [4.3]
+        r-version: [4.5]
     steps:
       - uses: actions/checkout@v4
       - name: Set up R ${{ matrix.r-version }}

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -33,13 +33,13 @@ jobs:
         with:
           r-version: ${{ matrix.r-version }}
       - name: Install Linux packages
-        run: sudo apt-get install -y mono-mcs mono-xbuild libcurl4-openssl-dev libicu-dev pandoc texlive texlive-latex-extra texlive-fonts-extra
+        run: sudo apt-get install -y libcurl4-openssl-dev libicu-dev pandoc texlive texlive-latex-extra texlive-fonts-extra
         shell: bash {0}
       - name: Install dependencies
         run: |
           install.packages("pak", repos = sprintf("https://r-lib.github.io/p/pak/stable/%s/%s/%s", .Platform$pkgType, R.Version()$os, R.Version()$arch))
           pak::pkg_install(c("covr", "rcmdcheck", "rmarkdown", "protViz", "testthat", "knitr"))
-          pak::pkg_install(c("bioc::BiocStyle", "bioc::ExperimentHub", "bioc::tartar"))
+          pak::pkg_install(c("bioc::BiocStyle", "bioc::ExperimentHub", "bioc::tartare"))
           pak::local_install_deps(dependencies = TRUE)
         shell: Rscript {0}
       - name: Check

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           r-version: ${{ matrix.r-version }}
       - name: Install Linux packages
-        run: sudo apt-get install -y mono-mcs mono-xbuild libcurl4-openssl-dev libicu-dev pandoc pandoc-citeproc texlive texlive-latex-extra texlive-fonts-extra
+        run: sudo apt-get install -y mono-mcs mono-xbuild libcurl4-openssl-dev libicu-dev pandoc texlive texlive-latex-extra texlive-fonts-extra
         shell: bash {0}
       - name: Install dependencies
         run: |

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -32,14 +32,16 @@ jobs:
         uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.r-version }}
+          use-public-rspm: true
       - name: Install Linux packages
         run: sudo apt-get install -y libcurl4-openssl-dev libicu-dev pandoc texlive texlive-latex-extra texlive-fonts-extra
         shell: bash {0}
       - name: Install dependencies
         run: |
           install.packages("pak", repos = sprintf("https://r-lib.github.io/p/pak/stable/%s/%s/%s", .Platform$pkgType, R.Version()$os, R.Version()$arch))
-          pak::pkg_install(c("covr", "rcmdcheck", "rmarkdown", "protViz", "testthat", "knitr"))
-          pak::pkg_install(c("bioc::BiocStyle", "bioc::ExperimentHub", "bioc::tartare"))
+          cat("Repository being used:\n")
+          print(getOption("repos"))
+          pak::pkg_install(c("covr", "rcmdcheck", "rmarkdown", "protViz", "testthat", "knitr", "bioc::BiocStyle", "bioc::ExperimentHub", "bioc::tartare"))
           pak::local_install_deps(dependencies = TRUE)
         shell: Rscript {0}
       - name: Check


### PR DESCRIPTION
Fixes

- Use R 4.5 for BioC 3.21 compatibility.
- Remove pandoc-citeproc package. Pandoc handles this natively now.
- Remove mono packages from pipeline.
- Correctly specify "tartare", we should maybe omit the dependencies which will be installed when installing the package later.

Enhances
- Use pak to unify installation of packages.
- Use RSPM for much faster install of dependencies.